### PR TITLE
Made service configuration lazy (allow export from wrapper cookbooks).

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ License and Authors
 
 Author: David Joos <david.joos@escapestudios.com>
 Author: Escape Studios Development <dev@escapestudios.com>
-Copyright: 2014, Escape Studios
+Copyright: 2014-2015, Escape Studios
 
 Unless otherwise noted, all files are released under the MIT license,
 possible exceptions will contain licensing information in them.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: newrelic_meetme_plugin
 # Attributes:: default
 #
-# Copyright 2014, Escape Studios
+# Copyright 2014-2015, Escape Studios
 #
 
 default['newrelic_meetme_plugin']['license'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'dev@escapestudios.com'
 license 'MIT'
 description 'Installs/Configures New Relic MeetMe plugin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.0'
+version '0.2.1'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos ).each do |os|
   supports os

--- a/providers/cfg.rb
+++ b/providers/cfg.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: newrelic_meetme_plugin
 # Provider:: cfg
 #
-# Copyright 2014, Escape Studios
+# Copyright 2014-2015, Escape Studios
 #
 
 require 'yaml'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: newrelic_meetme_plugin
 # Recipe:: default
 #
-# Copyright 2014, Escape Studios
+# Copyright 2014-2015, Escape Studios
 #
 
 include_recipe node['newrelic_meetme_plugin']['python_recipe']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ newrelic_meetme_plugin_cfg node['newrelic_meetme_plugin']['config_file'] do
   license license
   wake_interval node['newrelic_meetme_plugin']['wake_interval']
   proxy node['newrelic_meetme_plugin']['proxy']
-  services node['newrelic_meetme_plugin']['services']
+  services lazy { node['newrelic_meetme_plugin']['services'] }
   user node['newrelic_meetme_plugin']['user']
   pid_file node['newrelic_meetme_plugin']['pid_file']
   log_file node['newrelic_meetme_plugin']['log_file']

--- a/resources/cfg.rb
+++ b/resources/cfg.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: newrelic_meetme_plugin
 # Resource:: cfg
 #
-# Copyright 2014, Escape Studios
+# Copyright 2014-2015, Escape Studios
 #
 
 actions :generate


### PR DESCRIPTION
This simple PR to allows wrapper cookbooks to export services to `node.force_default['newrelic_meetme_plugin']['services']`.

Here is how I use the cookbook:
 - each recipe that installs services supported by meetme writes an entry into `node.force_default['newrelic_meetme_plugin']['services']`
 - when `recipe[newrelic_meetme_plugin]` runs, it collects all the services and dumps them into the meetme configuration files.

I use `node.force_default` instead of `node.default` to not depend on cookbook order in the run list.
Without the 'lazy' part, only services known at compile-time will be included, preventing dynamic export of meetme service entries in wrapper cookbooks.

Note: the services entries cannot be written in attributes (as with a role) because the service is not installed on all nodes, so they should only be monitored where they are is installed.