### PR TITLE
Fix typo in node['newrelic_meetme_plugin']['additional_requirements'].

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eg.
 * `node['newrelic_meetme_plugin']['pid_file']` - The New Relic plugin agent PID file name, defaults to "/var/run/newrelic/newrelic-plugin-agent.pid"
 * `node['newrelic_meetme_plugin']['log_file']` - The New Relic plugin agent log file name, defaults to "/var/log/newrelic/newrelic-plugin-agent.log"
 * `node['newrelic_meetme_plugin']['user']` - The New Relic plugin agent user, defaults to "newrelic". This user is not created by the cookbook or the PyPi package, so the default value will cause the plugin agent to fail if the `newrelic` user does not exist.
-* `node['newrelic_meetme_plugin']['additional_requirements']` - The New Relic plugin agent's additional requirements, eg. {"mongodb", "pgbouncer", "postgresql"} - defaults to {}
+* `node['newrelic_meetme_plugin']['additional_requirements']` - The New Relic plugin agent's additional requirements, eg. ["mongodb", "pgbouncer", "postgresql"] - defaults to []
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,4 +20,4 @@ default['newrelic_meetme_plugin']['config_file'] = '/etc/newrelic/newrelic-plugi
 default['newrelic_meetme_plugin']['pid_file'] = '/var/run/newrelic/newrelic-plugin-agent.pid'
 default['newrelic_meetme_plugin']['log_file'] = '/var/log/newrelic/newrelic-plugin-agent.log'
 default['newrelic_meetme_plugin']['user'] = 'newrelic'
-default['newrelic_meetme_plugin']['additional_requirements'] = {}
+default['newrelic_meetme_plugin']['additional_requirements'] = []


### PR DESCRIPTION
According to README.md, the `node['newrelic_meetme_plugin']['additional_requirements']` attribute has strange (and illegal) ruby syntax, half between Hash and Array syntaxes:

```
`node['newrelic_meetme_plugin']['additional_requirements']` - The New Relic plugin agent's additional requirements, eg. {"mongodb", "pgbouncer", "postgresql"} - defaults to {}
```

After checking the code, the code uses the attribute as an `Array` (iterate with `#each`, not with `#each_key`). This PR updates the README.md and the default value of the attribute to match the code.