### PR TITLE
Fix OpsWorks services YAML quotes don't get removed

### DIFF
--- a/providers/cfg.rb
+++ b/providers/cfg.rb
@@ -17,10 +17,10 @@ action :generate do
   services_yml = nil
 
   services = {
-    '#services' => new_resource.services
+    :services => new_resource.services
   }
 
-  services_yml = services.to_yaml(:indentation => 2).gsub(/(! )?['"]#services['"]:/, '#services:').gsub('---', '').gsub(%r{!(ruby\/|map|seq)[a-zA-Z:]*}, '')
+  services_yml = services.to_yaml(:indentation => 2).gsub(/(! )?:services:/, '#services:').gsub('---', '').gsub(%r{!(ruby\/|map|seq)[a-zA-Z:]*}, '')
 
   t = template new_resource.cfg_file do
     cookbook new_resource.template_cookbook


### PR DESCRIPTION
Thanks for all the hard work you've put in to share this recipe with the community. It works great except for one small problem that I ran into today. I can't figure out why, but it doesn't remove the quotes around the #service comment header in the generated CFG file. It ends up looking like this:

'#services:'

I'm using a stock Ubuntu 14.04 image on AWS, and I tried recreating my instance and various ways of setting the services attribute. 

I finally decided to try a small fix by using a :symbol instead of a 'string'. That works. I'm still pretty new to chef and ruby so this may not be the best way to solve the problem, but it works for me. If there's a better way, I'd be glad to hear about it.