### PR TITLE
For some reason Amazon Linux now installs this to /usr/local/bin, not /usr/bin

### DIFF
--- a/templates/default/newrelic-plugin-agent.erb
+++ b/templates/default/newrelic-plugin-agent.erb
@@ -9,7 +9,7 @@
 . /etc/init.d/functions
 
 # Application
-APP="/usr/bin/<%= @service_name %>"
+APP="/usr/local/bin/<%= @service_name %>"
 
 # PID File
 PID_FILE=<%= @pid_file %>


### PR DESCRIPTION
Just cloned a cluster I had running on Amazon Linux 2014.09 to a new cluster and changed the version to Amazon Linux 2015.03. 
For some reason, the agent was installed to /usr/local/bin but since the service template still expects it to be at /usr/bin the recipe failed.
I changed the service template to use /usr/local/bin and everything worked ok.
The only explanation I have is that this is a breaking change in Amazon Linux...